### PR TITLE
fix copy() bug when params has table value

### DIFF
--- a/router.lua
+++ b/router.lua
@@ -70,7 +70,7 @@ local function copy(t, visited)
   if type(t) ~= 'table' then return t end
   if visited[t] then return visited[t] end
   local result = {}
-  for k,v in pairs(t) do result[copy(k)] = copy(v) end
+  for k,v in pairs(t) do result[copy(k)] = copy(v, visited) end
   visited[t] = result
   return result
 end


### PR DESCRIPTION
When handle with:

* get request like `/test?foo=bar&bar=baz&bar=blah`
* post request with body `foo=bar&bar=baz&bar=blah`

`params`(first passing `t` to copy()) should be {foo = "bar", bar = {"baz", "blah"}}. 

The excute will throw an `attempt to index local 'visited' (a nil value)` error.