### PR TITLE
adding support for reading args without preceding / e.g /hello?a=b 

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ http {
 
       local ok, errmsg = r:execute(
         ngx.var.request_method,
-        ngx.var.request_uri,
+        ngx.var.uri,
         ngx.req.get_uri_args(),  -- all these parameters
         ngx.req.get_post_args(), -- will be merged in order
         {other_arg = 1})         -- into a single "params" table

--- a/router.lua
+++ b/router.lua
@@ -42,7 +42,10 @@ end
 local function resolve(path, node, params)
   local _, _, current_token, path = path:find("([^/.]+)(.*)")
   if not current_token then return node["LEAF"], params end
-
+  if string.match(current_token, '^?') then return node["LEAF"], params end
+  if string.match(current_token, '?') then
+      _, _, current_token, path = current_token:find("([^?.]+)(.*)")
+  end    
   for child_token, child_node in pairs(node) do
     if child_token == current_token then
       local f, bindings = resolve(path, child_node, params)


### PR DESCRIPTION
This PR fixes issue when query parameters are passed without preceding / 
 e.g below request uri doesn't match to ["/hello"] 

    GET  /hello?name=rjoshi  

will not match to 

     r:match({
       GET = {
          ["/hello"]       = function(params) ngx.print("someone said hello " .. params.name) end
        }

With this PR, it will work for below both

    GET /hello?name=rjoshi 
    GET /hello/?name=rjoshi