### PR TITLE
add function r:any() to match all methods

### DIFF
--- a/router.lua
+++ b/router.lua
@@ -31,6 +31,7 @@ local router = {
 
 local COLON_BYTE = string.byte(':', 1)
 local WILDCARD_BYTE = string.byte('*', 1)
+local HTTP_METHODS = {'get', 'post', 'put', 'patch', 'delete', 'trace', 'connect', 'options', 'head'}
 
 local function match_one_path(node, path, f)
   for token in path:gmatch("[^/.]+") do
@@ -124,10 +125,18 @@ function Router:match(method, path, f)
   end
 end
 
-for method in ("get post put patch delete trace connect options head"):gmatch("%S+") do
+for _,method in ipairs(HTTP_METHODS) do
   Router[method] = function(self, path, f)     -- Router.get = function(self, path, f)
     return self:match(method:upper(), path, f) --   return self:match('GET', path, f)
   end                                          -- end
+end
+
+Router['any'] = function(self, path, f) -- match any method
+  local methodt = {}
+  for _,method in ipairs(HTTP_METHODS) do
+    methodt[method:upper()] = {[path] = f}
+  end
+  return self:match(methodt, path, f)
 end
 
 local router_mt = { __index = Router }

--- a/router.lua
+++ b/router.lua
@@ -126,9 +126,9 @@ function Router:match(method, path, f)
 end
 
 for _,method in ipairs(HTTP_METHODS) do
-  Router[method] = function(self, path, f)                                          -- Router.get = function(self, path, f)
-    self:match(method:upper(), path, function(params) return f(params, method) end) --   return self:match('GET', path, f)
-  end                                                                               -- end
+  Router[method] = function(self, path, f)  -- Router.get = function(self, path, f)
+    self:match(method:upper(), path, f)     --   return self:match('GET', path, f)
+  end                                       -- end
 end
 
 Router['any'] = function(self, path, f) -- match any method

--- a/router.lua
+++ b/router.lua
@@ -110,7 +110,7 @@ end
 function Router:execute(method, path, ...)
   local f,params = self:resolve(method, path, ...)
   if not f then return nil, ('Could not resolve %s %s - %s'):format(method, path, params) end
-  return true, f(params, method)
+  return true, f(params)
 end
 
 function Router:match(method, path, f)
@@ -126,17 +126,15 @@ function Router:match(method, path, f)
 end
 
 for _,method in ipairs(HTTP_METHODS) do
-  Router[method] = function(self, path, f)     -- Router.get = function(self, path, f)
-    return self:match(method:upper(), path, f) --   return self:match('GET', path, f)
-  end                                          -- end
+  Router[method] = function(self, path, f)                                          -- Router.get = function(self, path, f)
+    self:match(method:upper(), path, function(params) return f(params, method) end) --   return self:match('GET', path, f)
+  end                                                                               -- end
 end
 
 Router['any'] = function(self, path, f) -- match any method
-  local methodt = {}
   for _,method in ipairs(HTTP_METHODS) do
-    methodt[method:upper()] = {[path] = f}
+    self:match(method:upper(), path, function(params) return f(params, method) end)
   end
-  return self:match(methodt, path, f)
 end
 
 local router_mt = { __index = Router }

--- a/router.lua
+++ b/router.lua
@@ -110,7 +110,7 @@ end
 function Router:execute(method, path, ...)
   local f,params = self:resolve(method, path, ...)
   if not f then return nil, ('Could not resolve %s %s - %s'):format(method, path, params) end
-  return true, f(params)
+  return true, f(params, method)
 end
 
 function Router:match(method, path, f)

--- a/spec/router_spec.lua
+++ b/spec/router_spec.lua
@@ -283,6 +283,15 @@ describe("Router", function()
         assert.same(dummy.params, {id = '21'})              --   assert.same(dummy.params, {id = '21'})
       end)                                                  -- end)
     end
+
+    it("passes the http method", function()
+      for method in ("get post put patch delete trace connect options head"):gmatch("%S+") do
+        local verb = method:upper()
+        r:any("/s/:id", function(params, method) dummy.params = {params = params, method = method} end)
+        r:execute(verb, "/s/21")
+        assert.same(dummy.params, {params = {id = '21'}, method = method})
+      end
+    end)
   end)
 
 end)

--- a/spec/router_spec.lua
+++ b/spec/router_spec.lua
@@ -274,4 +274,15 @@ describe("Router", function()
     end
   end)
 
+  describe("'any' shortcut", function()
+    for method in ("get post put patch delete trace connect options head"):gmatch("%S+") do
+      local verb = method:upper()
+      it(("matches a %s request"):format(verb), function()  -- it("matches a GET request", function()
+        r:any("/s/:id", write_dummy)                        --   r:any(r, "/s/:id", write_dummy)
+        r:execute(verb, "/s/21")                            --   r:execute(verb, "/s/21")
+        assert.same(dummy.params, {id = '21'})              --   assert.same(dummy.params, {id = '21'})
+      end)                                                  -- end)
+    end
+  end)
+
 end)


### PR DESCRIPTION
can be used just like `r:get`, but matches any method. can be useful to avoid some of the replication mentioned in #9.