### PR TITLE
Support for email address ( resource with .) in resource uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ http {
 
       local ok, errmsg = r:execute(
         ngx.var.request_method,
-        ngx.var.request_uri,
+        ngx.var.uri,
         ngx.req.get_uri_args(),  -- all these parameters
         ngx.req.get_post_args(), -- will be merged in order
         {other_arg = 1})         -- into a single "params" table


### PR DESCRIPTION
1.  I have added support for dot (.) in resource uri e.g `/emails/:email/devices` and request uri is  `/emails/abc.def@gmail.com/devices`
2. Updated readme to replace ngx.var.request_uri with ngx.var.uri . This will support uri without any subresources.