### PR TITLE
Preserve parameter's metatables

### DIFF
--- a/router.lua
+++ b/router.lua
@@ -89,6 +89,7 @@ local function merge(destination, origin, visited)
     end
   end
 
+  setmetatable(destination, getmetatable(origin))
   return destination
 end
 

--- a/spec/router_spec.lua
+++ b/spec/router_spec.lua
@@ -285,6 +285,14 @@ describe("Router", function()
           r:execute("POST", "/s/21", {bar = 'bar', baz = 'baz'}, {baz = 'hey'})
           assert.same(dummy.params, {id = '21', bar = 'bar', baz = 'baz'})
         end)
+
+        it("keeps metatables passed as parameters", function()
+          local meta = {__index = {addn = function(self,value) return value + self.n end}}
+          local param = {n = 5}
+          setmetatable(param, meta)
+          r:execute("POST", "/s/21", param)
+          assert.are.equal(dummy.params:addn(3), 5 + 3)
+        end)
       end)
     end) -- :execute
   end) -- default params


### PR DESCRIPTION
If parameters with metatables are passed to :execute(), preserve the metatables in the parameters passed to the matched function. This may solve some cases of #29 .